### PR TITLE
Update google translator's url to translate.google.com.hk

### DIFF
--- a/Android/GoogleTranslateUtil.java
+++ b/Android/GoogleTranslateUtil.java
@@ -20,7 +20,7 @@ public class GoogleTranslateUtil {
     private GoogleTranslateUtil() {
     }
 
-    String url = "https://translate.google.cn/translate_a/single";
+    String url = "https://translate.google.com.hk/translate_a/single";
     String tkk = "434674.96463358"; // 随时都有可能需要更新的TKK值
 
     public long uo(long a, String b) {
@@ -82,7 +82,7 @@ public class GoogleTranslateUtil {
             connection.setRequestProperty("accept", "*/*");
             connection.setRequestProperty("accept-language", "zh-CN,zh;q=0.9");
             connection.setRequestProperty("cookie", "NID=188=M1p_rBfweeI_Z02d1MOSQ5abYsPfZogDrFjKwIUbmAr584bc9GBZkfDwKQ80cQCQC34zwD4ZYHFMUf4F59aDQLSc79_LcmsAihnW0Rsb1MjlzLNElWihv-8KByeDBblR2V1kjTSC8KnVMe32PNSJBQbvBKvgl4CTfzvaIEgkqss");
-            connection.setRequestProperty("referer", "https://translate.google.cn/");
+            connection.setRequestProperty("referer", "https://translate.google.com.hk/");
             connection.setRequestProperty("x-client-data", "CJK2yQEIpLbJAQjEtskBCKmdygEIqKPKAQi5pcoBCLGnygEI4qjKAQjxqcoBCJetygEIza3KAQ==");
             connection.setRequestProperty("user-agent",
                     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36");
@@ -124,7 +124,7 @@ public class GoogleTranslateUtil {
 
     public String update_TKK() {
         try {
-            String tkkUrl = "https://translate.google.cn/";
+            String tkkUrl = "https://translate.google.com.hk/";
             String req = sendGet(tkkUrl);
             Pattern pattern = Pattern.compile("tkk:'([0-9]+\\.[0-9]+)'");
             Matcher matcher = pattern.matcher(req);

--- a/Python/GoogleTranslator.py
+++ b/Python/GoogleTranslator.py
@@ -15,14 +15,14 @@ ssl._create_default_https_context = ssl._create_unverified_context
 
 class GoogleTrans(object):
     def __init__(self):
-        self.url = 'https://translate.google.cn/translate_a/single'
+        self.url = 'https://translate.google.com.hk/translate_a/single'
         self.TKK = "434674.96463358"  # 随时都有可能需要更新的TKK值
         
         self.header = {
             "accept": "*/*",
             "accept-language": "zh-CN,zh;q=0.9",
             "cookie": "NID=188=M1p_rBfweeI_Z02d1MOSQ5abYsPfZogDrFjKwIUbmAr584bc9GBZkfDwKQ80cQCQC34zwD4ZYHFMUf4F59aDQLSc79_LcmsAihnW0Rsb1MjlzLNElWihv-8KByeDBblR2V1kjTSC8KnVMe32PNSJBQbvBKvgl4CTfzvaIEgkqss",
-            "referer": "https://translate.google.cn/",
+            "referer": "https://translate.google.com.hk/",
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
             "x-client-data": "CJK2yQEIpLbJAQjEtskBCKmdygEIqKPKAQi5pcoBCLGnygEI4qjKAQjxqcoBCJetygEIza3KAQ==",
         }
@@ -153,7 +153,7 @@ class GoogleTrans(object):
     
     
     def update_TKK(self):
-        url = "https://translate.google.cn/"
+        url = "https://translate.google.com.hk/"
         req = requests.get(url, headers=self.header)
         page_source = req.text
         self.TKK = re.findall(r"tkk:'([0-9]+\.[0-9]+)'", page_source)[0]

--- a/Python/GoogleTranslatorWithJs.py
+++ b/Python/GoogleTranslatorWithJs.py
@@ -13,14 +13,14 @@ ssl._create_default_https_context = ssl._create_unverified_context
 
 class GoogleTrans(object):
     def __init__(self):
-        self.url = 'https://translate.google.cn/translate_a/single'
+        self.url = 'https://translate.google.com.hk/translate_a/single'
         self.TKK = "434674.96463358"  # 随时都有可能需要更新的TKK值
         
         self.header = {
             "accept": "*/*",
             "accept-language": "zh-CN,zh;q=0.9",
             "cookie": "NID=188=M1p_rBfweeI_Z02d1MOSQ5abYsPfZogDrFjKwIUbmAr584bc9GBZkfDwKQ80cQCQC34zwD4ZYHFMUf4F59aDQLSc79_LcmsAihnW0Rsb1MjlzLNElWihv-8KByeDBblR2V1kjTSC8KnVMe32PNSJBQbvBKvgl4CTfzvaIEgkqss",
-            "referer": "https://translate.google.cn/",
+            "referer": "https://translate.google.com.hk/",
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
             "x-client-data": "CJK2yQEIpLbJAQjEtskBCKmdygEIqKPKAQi5pcoBCLGnygEI4qjKAQjxqcoBCJetygEIza3KAQ==",
         }
@@ -47,7 +47,7 @@ class GoogleTrans(object):
     
     
     def update_TKK(self):
-        url = "https://translate.google.cn/"
+        url = "https://translate.google.com.hk/"
         req = urllib.request.Request(url=url, headers = self.header)
         page_source = urllib.request.urlopen(req).read().decode("utf-8")
         self.TKK = re.findall(r"tkk:'([0-9]+\.[0-9]+)'", page_source)[0]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![made-with-javascript](https://img.shields.io/badge/Made%20with-JavaScript-1f425f.svg)](https://www.javascript.com)
 [![Ask Me Anything !](https://img.shields.io/badge/Ask%20me-anything-1abc9c.svg)](https://GitHub.com/Naereen/ama)
 
-Free Google Translate is a tool for google free translation API, the main idea of the repo is coming from the web `https://translate.google.cn` translation, we use a hacking way to access the web translation api for translating text.
+Free Google Translate is a tool for google free translation API, the main idea of the repo is coming from the web `https://translate.google.com.hk` translation, we use a hacking way to access the web translation api for translating text.
 
 
 # The Do's and Don'ts
@@ -60,7 +60,7 @@ The response data is as same as aforementioned python code.
 
 
 # free-google-translate
-Free Google Translator API 免费的Google翻译，其中的破解思路主要来源于将 https://translate.google.cn 的web访问方式模拟成全部代码的形式来控制api的访问
+Free Google Translator API 免费的Google翻译，其中的破解思路主要来源于将 https://translate.google.com.hk 的web访问方式模拟成全部代码的形式来控制api的访问
 
 # 注意事项
 - 1.大量的相同IP请求会导致Google翻译接口返回 429 Too many requests 

--- a/iOS/YLGoogleTranslate.m
+++ b/iOS/YLGoogleTranslate.m
@@ -26,13 +26,13 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _url = @"https://translate.google.cn/translate_a/single";
+        _url = @"https://translate.google.com.hk/translate_a/single";
         _TKK = @"434674.96463358";  // 随时都有可能需要更新的TKK值
         _header = @{
                         @"accept": @"*/*",
                         @"accept-language": @"zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7",
                         @"cookie": @"NID=188=M1p_rBfweeI_Z02d1MOSQ5abYsPfZogDrFjKwIUbmAr584bc9GBZkfDwKQ80cQCQC34zwD4ZYHFMUf4F59aDQLSc79_LcmsAihnW0Rsb1MjlzLNElWihv-8KByeDBblR2V1kjTSC8KnVMe32PNSJBQbvBKvgl4CTfzvaIEgkqss",
-                        @"referer": @"https://translate.google.cn/",
+                        @"referer": @"https://translate.google.com.hk/",
                         @"user-agent": @"Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1",
                         @"x-client-data": @"CJK2yQEIpLbJAQjEtskBCKmdygEIqKPKAQi5pcoBCLGnygEI4qjKAQjxqcoBCJetygEIza3KAQ==",
                     };
@@ -55,7 +55,7 @@
 }
 
 - (void)getTKKInCompletion:(void (^)(NSString * _Nullable tkkData, NSString * _Nullable error))completionHandler {
-    NSString *url = @"https://translate.google.cn/";
+    NSString *url = @"https://translate.google.com.hk/";
     [self requestWithUrl:url method:@"GET" header:self.header completionHandler:^(NSData * _Nullable respData, NSError * _Nullable error) {
         if (error) {
             completionHandler(nil, error.localizedDescription);


### PR DESCRIPTION
2022年开始，谷歌关停了translate.google.cn的服务。但是translate.google.com.hk可以在科学上网的前提下访问。
我使用多文件搜索把所有translate.google.cn的域名都替换成了translate.google.com.hk。我测试了python脚本可用。iOS和Andriod的代码没有测试，但我想功能应该没有发生变化。

Since 2022, google shut up the service of translate.google.cn. But translate.google.com.hk could be visited when over the GFW.
I replaced all the url of translate.google.cn to translate.google.com.hk by tools automatically. I tested the python scripts is usable. The code of iOS and Andriod not is tested, but I think its function is not changed.